### PR TITLE
puppet-nodejs: change exec_as_user to user

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,7 @@ class sinopia (
     ensure  => present,
     require => [File[$install_path,$modules_path],User[$deamon_user]],
     notify  => $service_notify,
+    target  => "{$install_path}",
     user    => $deamon_user,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,10 +66,10 @@ class sinopia (
     true => Service['sinopia']
   }
   nodejs::npm { "${install_path}:sinopia":
-    ensure       => present,
-    require      => [File[$install_path,$modules_path],User[$deamon_user]],
-    notify       => $service_notify,
-    exec_as_user => $deamon_user,
+    ensure  => present,
+    require => [File[$install_path,$modules_path],User[$deamon_user]],
+    notify  => $service_notify,
+    user    => $deamon_user,
   }
 
   ###


### PR DESCRIPTION
The puppet-nodejs module has changed from using exec_as_user to user
